### PR TITLE
Configure linker to lld for windows target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+linker = "lld-link"


### PR DESCRIPTION
During compilation, both Linux and cross-compilation via Xwin defaults to the LLVM linker (lld-link).

However, on native Windows, it appears that the default linker is the MSVC linker (link.exe), at least on my VM.

As a result, when attempting to generate a dllproxy, the process failed due to undefined symbols because the exports were in an incompatible format for the MSVC linker.

This commit configures Cargo to use the LLVM linker for the x86_64-pc-windows-msvc target, allowing to generate a dllproxy directly on Windows.